### PR TITLE
feat: Account name completion.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,7 +54,7 @@
             - since the underlying file changes while typing for the completion, this is difficult
             - however, typing a new account name does not change the list since the currently type account name should be ignored anyway
             - the question is: how do we recognize a cached list that is valid to use?
-        - [ ] prefilter list
+        - [x] prefilter list
         - [ ] remove the currently hovered account name from the list, since it is incomplete
 - [ ] code completion for account names
     - [ ] based on prefix-syntax, e.g. `exp:Ca:Che` should suggest `expenses:Cash:Checking`, if it exists

--- a/TODO.md
+++ b/TODO.md
@@ -48,5 +48,9 @@
     - optimizations:
         - [ ] don't parse file to AST in each subsequent request, but once after adding the file to the cache
         - [ ] don't parse the file immediately after adding it to the cache, but memoize the AST after it is requested the first time
+- completion
+    - account names
+        - [ ] prefilter list
+        - [ ] remove the currently hovered account name from the list, since it is incomplete
 - [ ] code completion for account names
     - [ ] based on prefix-syntax, e.g. `exp:Ca:Che` should suggest `expenses:Cash:Checking`, if it exists

--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,10 @@
         - [ ] don't parse the file immediately after adding it to the cache, but memoize the AST after it is requested the first time
 - completion
     - account names
+        - [ ] cache list somehow
+            - since the underlying file changes while typing for the completion, this is difficult
+            - however, typing a new account name does not change the list since the currently type account name should be ignored anyway
+            - the question is: how do we recognize a cached list that is valid to use?
         - [ ] prefilter list
         - [ ] remove the currently hovered account name from the list, since it is incomplete
 - [ ] code completion for account names

--- a/TODO.md
+++ b/TODO.md
@@ -38,12 +38,12 @@
     - [ ] support indented additional comments
 - integration
     - [ ] support finding an AST token by position in a file
+        - works for account names
 
 ## language server
 - [x] bug: currently hover should give the account name under cursor, but it can't deal with the resolved includes
 - [ ] cache files and track changes in memory
     - [x] extract cache into dedicated module
-    - [ ] maybe add versioning?
     - [x] test it
     - optimizations:
         - [ ] don't parse file to AST in each subsequent request, but once after adding the file to the cache
@@ -55,6 +55,6 @@
             - however, typing a new account name does not change the list since the currently type account name should be ignored anyway
             - the question is: how do we recognize a cached list that is valid to use?
         - [x] prefilter list
-        - [ ] remove the currently hovered account name from the list, since it is incomplete
-- [ ] code completion for account names
-    - [ ] based on prefix-syntax, e.g. `exp:Ca:Che` should suggest `expenses:Cash:Checking`, if it exists
+            - [x] based on prefix-syntax, e.g. `exp:Ca:Che` should suggest `expenses:Cash:Checking`, if it exists
+            - [ ] fuzzy match for each segment
+        - [x] remove the currently hovered account name from the list, since it is incomplete

--- a/ledger/journalparser.go
+++ b/ledger/journalparser.go
@@ -51,6 +51,18 @@ func (accountName *AccountName) Prefixes() []AccountName {
 	return prefixes
 }
 
+func (accountName AccountName) Equals(otherAccountName AccountName) bool {
+	if len(accountName.Segments) != len(otherAccountName.Segments) {
+		return false
+	}
+	for i, segment := range accountName.Segments {
+		if otherAccountName.Segments[i] != segment {
+			return false
+		}
+	}
+	return true
+}
+
 type RealPosting struct {
 	PostingStatus string       `parser:"Indent (@('*' | '!') ' ')?"`
 	AccountName   *AccountName `parser:"@@"`

--- a/ledger/journalparser.go
+++ b/ledger/journalparser.go
@@ -38,6 +38,19 @@ func (accountName *AccountName) String() string {
 	return strings.Join(accountName.Segments, ":")
 }
 
+func (accountName *AccountName) Prefixes() []AccountName {
+	prefixes := make([]AccountName, len(accountName.Segments))
+
+	for i := range accountName.Segments {
+		prefixes[i] = AccountName{Segments: make([]string, i+1)}
+		for j := 0; j <= i; j++ {
+			prefixes[i].Segments[j] = accountName.Segments[j]
+		}
+	}
+
+	return prefixes
+}
+
 type RealPosting struct {
 	PostingStatus string       `parser:"Indent (@('*' | '!') ' ')?"`
 	AccountName   *AccountName `parser:"@@"`

--- a/ledger/journalparser_test.go
+++ b/ledger/journalparser_test.go
@@ -241,3 +241,37 @@ commodity EUR
 		})
 	})
 }
+
+func TestAccountName(t *testing.T) {
+	t.Run("Prefixes", func(t *testing.T) {
+		t.Run("returns an empty list if the account name has no segments.", func(t *testing.T) {
+			accountName := &ledger.AccountName{
+				Segments: []string{},
+			}
+
+			prefixes := accountName.Prefixes()
+
+			assert.Equal(t, []ledger.AccountName{}, prefixes)
+		})
+
+		t.Run("returns all segment prefixes of the account name.", func(t *testing.T) {
+			accountName := &ledger.AccountName{
+				Segments: []string{"assets", "Cash", "Checking", "Whatever", "another layer"},
+			}
+
+			prefixes := accountName.Prefixes()
+
+			assert.Equal(
+				t,
+				[]ledger.AccountName{
+					{Segments: []string{"assets"}},
+					{Segments: []string{"assets", "Cash"}},
+					{Segments: []string{"assets", "Cash", "Checking"}},
+					{Segments: []string{"assets", "Cash", "Checking", "Whatever"}},
+					{Segments: []string{"assets", "Cash", "Checking", "Whatever", "another layer"}},
+				},
+				prefixes,
+			)
+		})
+	})
+}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -25,3 +25,41 @@ func FindAccountNameUnderCursor(journal *Journal, fileName string, line, column 
 
 	return nil
 }
+
+func AccountNames(journal *Journal) []string {
+	accountNameSet := make(map[string]interface{})
+
+	for _, entry := range journal.Entries {
+		switch entry := entry.(type) {
+		case *AccountDirective:
+			if entry.AccountName == nil {
+				continue
+			}
+			accountNameSet[entry.AccountName.String()] = struct{}{}
+		case *RealPosting:
+			if entry.AccountName == nil {
+				continue
+			}
+			accountNameSet[entry.AccountName.String()] = struct{}{}
+		case *VirtualPosting:
+			if entry.AccountName == nil {
+				continue
+			}
+			accountNameSet[entry.AccountName.String()] = struct{}{}
+		case *VirtualBalancedPosting:
+			if entry.AccountName == nil {
+				continue
+			}
+			accountNameSet[entry.AccountName.String()] = struct{}{}
+		default:
+			continue
+		}
+	}
+
+	accountNames := make([]string, 0, len(accountNameSet))
+	for accountName := range accountNameSet {
+		accountNames = append(accountNames, accountName)
+	}
+
+	return accountNames
+}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -1,5 +1,7 @@
 package ledger
 
+import "strings"
+
 // FindAccountNameUnderCursor's parameters line and column are 1-based.
 func FindAccountNameUnderCursor(journal *Journal, fileName string, line, column int) *AccountName {
 	for _, entry := range journal.Entries {
@@ -26,40 +28,79 @@ func FindAccountNameUnderCursor(journal *Journal, fileName string, line, column 
 	return nil
 }
 
-func AccountNames(journal *Journal) []string {
-	accountNameSet := make(map[string]interface{})
+func AccountNames(journal *Journal) []AccountName {
+	accountNameSet := make(map[string]AccountName)
 
 	for _, entry := range journal.Entries {
+		var accountName *AccountName
+
 		switch entry := entry.(type) {
 		case *AccountDirective:
 			if entry.AccountName == nil {
 				continue
 			}
-			accountNameSet[entry.AccountName.String()] = struct{}{}
+			accountName = entry.AccountName
 		case *RealPosting:
 			if entry.AccountName == nil {
 				continue
 			}
-			accountNameSet[entry.AccountName.String()] = struct{}{}
+			accountName = entry.AccountName
 		case *VirtualPosting:
 			if entry.AccountName == nil {
 				continue
 			}
-			accountNameSet[entry.AccountName.String()] = struct{}{}
+			accountName = entry.AccountName
 		case *VirtualBalancedPosting:
 			if entry.AccountName == nil {
 				continue
 			}
-			accountNameSet[entry.AccountName.String()] = struct{}{}
+			accountName = entry.AccountName
 		default:
 			continue
 		}
+
+		prefixes := accountName.Prefixes()
+		for _, prefix := range prefixes {
+			accountNameSet[prefix.String()] = prefix
+		}
 	}
 
-	accountNames := make([]string, 0, len(accountNameSet))
-	for accountName := range accountNameSet {
+	accountNames := make([]AccountName, 0, len(accountNameSet))
+	for _, accountName := range accountNameSet {
 		accountNames = append(accountNames, accountName)
 	}
 
 	return accountNames
+}
+
+// TODO: fuzzy match segments
+func FilterAccountNamesByPrefix(accountNames []AccountName, query *AccountName) []AccountName {
+	minLength := 1
+	maxLength := 1
+	if query != nil {
+		minLength = len(query.Segments)
+		maxLength = minLength + 1
+	}
+
+	matchingAccountNames := make([]AccountName, 0)
+accountNameLoop:
+	for _, accountName := range accountNames {
+		if len(accountName.Segments) > maxLength || len(accountName.Segments) < minLength {
+			continue
+		}
+
+		if query == nil {
+			matchingAccountNames = append(matchingAccountNames, accountName)
+			continue
+		}
+
+		for i, segment := range query.Segments {
+			if _, ok := strings.CutPrefix(accountName.Segments[i], segment); !ok {
+				continue accountNameLoop
+			}
+		}
+		matchingAccountNames = append(matchingAccountNames, accountName)
+	}
+
+	return matchingAccountNames
 }

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -1,0 +1,79 @@
+package ledger_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yeldiRium/hledger-language-server/ledger"
+)
+
+func TestFilterAccountNamesByPrefix(t *testing.T) {
+	t.Run("returns an empty list if no account names are given.", func(t *testing.T) {
+		accountNames := []ledger.AccountName{}
+
+		matchingAccountNames := ledger.FilterAccountNamesByPrefix(accountNames, nil)
+
+		assert.Equal(t, []ledger.AccountName{}, matchingAccountNames)
+	})
+
+	t.Run("returns all 1-length account names if no query is given", func(t *testing.T) {
+		accountNames := []ledger.AccountName{
+			{Segments: []string{"assets"}},
+			{Segments: []string{"assets", "Cash"}},
+			{Segments: []string{"assets", "Cash", "Checking"}},
+			{Segments: []string{"assets", "Capital"}},
+			{Segments: []string{"assets", "Capital", "ETFs"}},
+			{Segments: []string{"revenue"}},
+			{Segments: []string{"revenue", "Salary"}},
+		}
+
+		matchingAccountNames := ledger.FilterAccountNamesByPrefix(accountNames, nil)
+
+		assert.Equal(
+			t,
+			[]ledger.AccountName{
+				{Segments: []string{"assets"}},
+				{Segments: []string{"revenue"}},
+			},
+			matchingAccountNames,
+		)
+	})
+
+	t.Run("returns all account names matching the query that are at most one segment longer than the query.", func(t *testing.T) {
+		accountNames := []ledger.AccountName{
+			{Segments: []string{"assets"}},
+			{Segments: []string{"assets", "Cash"}},
+			{Segments: []string{"assets", "Cash", "Checking"}},
+			{Segments: []string{"assets", "Capital"}},
+			{Segments: []string{"assets", "Capital", "ETFs"}},
+			{Segments: []string{"revenue"}},
+			{Segments: []string{"revenue", "Salary"}},
+		}
+
+		type testCase struct {
+			query                *ledger.AccountName
+			expectedAccountNames []ledger.AccountName
+		}
+
+		testCases := []testCase{
+			{
+				query: &ledger.AccountName{
+					Segments: []string{"ass"},
+				},
+				expectedAccountNames: []ledger.AccountName{
+					{Segments: []string{"assets"}},
+					{Segments: []string{"assets", "Cash"}},
+					{Segments: []string{"assets", "Capital"}},
+				},
+			},
+		}
+		for i, testCase := range testCases {
+			t.Run(fmt.Sprintf("Test case %d", i), func(t *testing.T) {
+				matchingAccountNames := ledger.FilterAccountNamesByPrefix(accountNames, testCase.query)
+
+				assert.Equal(t, testCase.expectedAccountNames, matchingAccountNames)
+			})
+		}
+	})
+}

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -8,6 +8,49 @@ import (
 	"github.com/yeldiRium/hledger-language-server/ledger"
 )
 
+func TestAccountNames(t *testing.T) {
+	t.Run("returns an empty list for an empty journal.", func(t *testing.T) {
+		journal := &ledger.Journal{
+			Entries: []ledger.Entry{},
+		}
+
+		accountNames := ledger.AccountNames(journal)
+
+		assert.Equal(t, []ledger.AccountName{}, accountNames)
+	})
+
+	t.Run("returns a list of all account names and their prefixes in the journal.", func(t *testing.T) {
+		journal := &ledger.Journal{
+			Entries: []ledger.Entry{
+				&ledger.AccountDirective{
+					AccountName: &ledger.AccountName{
+						Segments: []string{"assets", "Cash", "Checking"},
+					},
+				},
+				&ledger.AccountDirective{
+					AccountName: &ledger.AccountName{
+						Segments: []string{"revenue", "Salary"},
+					},
+				},
+			},
+		}
+
+		accountNames := ledger.AccountNames(journal)
+
+		assert.ElementsMatch(
+			t,
+			[]ledger.AccountName{
+				{Segments: []string{"assets"}},
+				{Segments: []string{"assets", "Cash"}},
+				{Segments: []string{"assets", "Cash", "Checking"}},
+				{Segments: []string{"revenue"}},
+				{Segments: []string{"revenue", "Salary"}},
+			},
+			accountNames,
+		)
+	})
+}
+
 func TestFilterAccountNamesByPrefix(t *testing.T) {
 	t.Run("returns an empty list if no account names are given.", func(t *testing.T) {
 		accountNames := []ledger.AccountName{}

--- a/server/completion.go
+++ b/server/completion.go
@@ -76,13 +76,23 @@ func (server server) Completion(ctx context.Context, params *protocol.Completion
 	matchingAccountNames := ledger.FilterAccountNamesByPrefix(accountNames, accountNameUnderCursor)
 
 	result := protocol.CompletionList{
-		IsIncomplete: false,
+		IsIncomplete: true,
 		Items:        make([]protocol.CompletionItem, len(accountNames)),
 	}
 
 	for i, accountName := range matchingAccountNames {
 		result.Items[i] = protocol.CompletionItem{
 			Label: accountName.String(),
+			TextEdit: &protocol.TextEdit{
+				Range: protocol.Range{
+					Start: protocol.Position{
+						Line: uint32(accountNameUnderCursor.Pos.Line - 1),
+						Character: uint32(accountNameUnderCursor.Pos.Column - 1),
+					},
+					End: params.Position,
+				},
+				NewText: accountName.String(),
+			},
 		}
 	}
 

--- a/server/completion.go
+++ b/server/completion.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/yeldiRium/hledger-language-server/ledger"
@@ -67,6 +68,11 @@ func (server server) Completion(ctx context.Context, params *protocol.Completion
 	accountNameUnderCursor := ledger.FindAccountNameUnderCursor(resolvedJournal, fileName, lineNumber, columnNumber)
 
 	accountNames := ledger.AccountNames(resolvedJournal)
+	if accountNameUnderCursor != nil {
+		accountNames = slices.DeleteFunc(accountNames, func(accountName ledger.AccountName) bool {
+			return accountName.Equals(*accountNameUnderCursor)
+		})
+	}
 	matchingAccountNames := ledger.FilterAccountNamesByPrefix(accountNames, accountNameUnderCursor)
 
 	result := protocol.CompletionList{

--- a/server/completion.go
+++ b/server/completion.go
@@ -33,6 +33,7 @@ func (server server) Completion(ctx context.Context, params *protocol.Completion
 	fileContent, ok := server.cache.GetFile(params.TextDocument.URI)
 	var fileReader io.Reader
 	if !ok {
+		// TODO: should never open from file system. always go via cache
 		server.logger.Warn(
 			"textDocument/hover target not found in cache, opening from file system",
 			zap.String("DocumentURI", string(params.TextDocument.URI)),
@@ -55,20 +56,27 @@ func (server server) Completion(ctx context.Context, params *protocol.Completion
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse journal: %w", err)
 	}
+	// TODO: resolves need to respect the cache
 	resolvedJournal, err := ledger.ResolveIncludes(journal, parser, os.DirFS(path.Dir(fileName)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve includes: %w", err)
 	}
+
+	lineNumber := int(params.Position.Line + 1)
+	columnNumber := int(params.Position.Character + 1)
+	accountNameUnderCursor := ledger.FindAccountNameUnderCursor(resolvedJournal, fileName, lineNumber, columnNumber)
+
 	accountNames := ledger.AccountNames(resolvedJournal)
+	matchingAccountNames := ledger.FilterAccountNamesByPrefix(accountNames, accountNameUnderCursor)
 
 	result := protocol.CompletionList{
 		IsIncomplete: false,
 		Items:        make([]protocol.CompletionItem, len(accountNames)),
 	}
 
-	for i, accountName := range accountNames {
+	for i, accountName := range matchingAccountNames {
 		result.Items[i] = protocol.CompletionItem{
-			Label: accountName,
+			Label: accountName.String(),
 		}
 	}
 

--- a/server/completion.go
+++ b/server/completion.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/yeldiRium/hledger-language-server/ledger"
+	"go.lsp.dev/protocol"
+	"go.uber.org/zap"
+)
+
+func registerCompletionCapabilities(capabilities *protocol.ServerCapabilities) {
+	capabilities.CompletionProvider = &protocol.CompletionOptions{
+		ResolveProvider:   false,
+		TriggerCharacters: strings.Split("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 :", ""),
+	}
+}
+
+func (server server) Completion(ctx context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error) {
+	server.logger.Debug(
+		"textDocument/completion",
+		zap.String("documentURI", string(params.TextDocument.URI)),
+	)
+
+	fileName := params.TextDocument.URI.Filename()
+	fileName = strings.TrimPrefix(fileName, "file://")
+
+	fileContent, ok := server.cache.GetFile(params.TextDocument.URI)
+	var fileReader io.Reader
+	if !ok {
+		server.logger.Warn(
+			"textDocument/hover target not found in cache, opening from file system",
+			zap.String("DocumentURI", string(params.TextDocument.URI)),
+		)
+		fileReader, err := os.Open(fileName)
+		defer fileReader.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to open file: %w", err)
+		}
+	} else {
+		server.logger.Info(
+			"textDocument/hover target found in cache",
+			zap.String("DocumentURI", string(params.TextDocument.URI)),
+		)
+		fileReader = bytes.NewBuffer([]byte(fileContent))
+	}
+
+	parser := ledger.NewJournalParser()
+	journal, err := parser.Parse(fileName, fileReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse journal: %w", err)
+	}
+	resolvedJournal, err := ledger.ResolveIncludes(journal, parser, os.DirFS(path.Dir(fileName)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve includes: %w", err)
+	}
+	accountNames := ledger.AccountNames(resolvedJournal)
+
+	result := protocol.CompletionList{
+		IsIncomplete: false,
+		Items:        make([]protocol.CompletionItem, len(accountNames)),
+	}
+
+	for i, accountName := range accountNames {
+		result.Items[i] = protocol.CompletionItem{
+			Label: accountName,
+		}
+	}
+
+	return &result, nil
+}


### PR DESCRIPTION
Implements the `completion` method of the language server protocol.

Suggests account names that are found in the open document (and all documents referenced via `include`). The suggestions are pre-filtered based on per-segment prefix matching. I.e. if the document contains the account names "assets:Cash" and "assets:Savings", completing based on the currently hovered text "ass:Ca" will only suggest "assets:Cash".